### PR TITLE
feat: Display list of scrolls on the homepage

### DIFF
--- a/app/[slugs]/page.tsx
+++ b/app/[slugs]/page.tsx
@@ -11,14 +11,14 @@ interface Props {
 }
 
 export async function generateStaticParams() {
-  const files = fs.readdirSync(path.join(process.cwd(), 'scrolls'));
+  const files = fs.readdirSync(path.join(process.cwd(), 'app', 'scrolls'));
   return files.map((filename) => ({
     slug: filename.replace('.md', ''),
   }));
 }
 
 export default async function ScrollPage({ params }: Props) {
-  const filePath = path.join(process.cwd(), 'scrolls', `${params.slug}.md`);
+  const filePath = path.join(process.cwd(), 'app', 'scrolls', `${params.slug}.md`);
 
   let content = '';
   let title = 'Scroll Not Found';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,33 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import Link from 'next/link';
+
 export default function Home() {
+  const scrollsDir = path.join(process.cwd(), 'app', 'scrolls');
+  const filenames = fs.readdirSync(scrollsDir);
+
+  const scrolls = filenames
+    .filter((filename) => filename.endsWith('.md'))
+    .map((filename) => {
+      const filePath = path.join(scrollsDir, filename);
+      const fileContents = fs.readFileSync(filePath, 'utf8');
+      const { data } = matter(fileContents);
+      return {
+        slug: filename.replace('.md', ''),
+        title: data.title || filename.replace('.md', ''),
+      };
+    });
+
   return (
     <main>
-      <h1>The Unbreaking</h1>
-      <p>Your sacred scrollsite is live.</p>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {scrolls.map((scroll) => (
+          <Link key={scroll.slug} href={`/${scroll.slug}`} className="block p-6 bg-gray-800/50 rounded-lg border border-gray-700 hover:bg-gray-700/50 transition-colors duration-300">
+            <h2 className="text-2xl font-bold text-purple-400">{scroll.title}</h2>
+          </Link>
+        ))}
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
The homepage was previously a placeholder. This change reads the available scrolls from the `app/scrolls` directory and displays them as a list of links on the homepage.

- Modified `app/page.tsx` to read the scrolls directory and render a list of links.
- Added Tailwind CSS styling to the list for a better visual appearance.
- Fixed the file path in `app/[slugs]/page.tsx` to correctly locate the scroll files in the `app/scrolls` directory.